### PR TITLE
Fixed fonts in header on home page on macOS

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Gruba.IT</title>
-    <link href="https://fonts.googleapis.com/css?family=Work+Sans&amp;subset=latin-ext" rel="stylesheet">
     <link rel="shortcut icon" type="image/png" href="images/favicon.png"/>
 </head>
 <body>

--- a/src/styles/basic/reset.scss
+++ b/src/styles/basic/reset.scss
@@ -7,8 +7,8 @@ b, u, i, center,
 dl, dt, dd, ol, ul, li,
 fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
 	margin: 0;
@@ -19,7 +19,7 @@ time, mark, audio, video {
 	vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
+article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
 	display: block;
 }

--- a/src/styles/components/all.scss
+++ b/src/styles/components/all.scss
@@ -11,4 +11,3 @@
 @import 'scroll-down';
 @import 'countdown';
 @import 'subpage';
-@import url('https://fonts.googleapis.com/css?family=Inconsolata:400,700&amp;subset=latin-ext');

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,9 +1,12 @@
+@import url('https://fonts.googleapis.com/css?family=Inconsolata:400,700&amp;subset=latin-ext');
+@import url('https://fonts.googleapis.com/css?family=Work+Sans:400,600&amp;subset=latin-ext');
+
 @import 'variables';
+@import 'components/all';
 @import '~grommet/scss/grommet-core/index';
 @import 'basic/all';
 @import 'themes/all';
 @import 'containers/all';
-@import 'components/all';
 
 * {
 	box-sizing: border-box;


### PR DESCRIPTION
This is a fix for missing fonts on the home page. 

Before:
![screenshot 2018-10-27 at 20 26 39](https://user-images.githubusercontent.com/20810956/47607914-bf6cef80-da26-11e8-8308-30796ec9e101.png)

After:
![screenshot 2018-10-27 at 20 26 43](https://user-images.githubusercontent.com/20810956/47607917-c693fd80-da26-11e8-8fe1-84287e7a86c3.png)
