### PR TITLE
Fixed overlapping mail icon

### DIFF
--- a/src/styles/components/team.scss
+++ b/src/styles/components/team.scss
@@ -54,4 +54,11 @@
         background-size: cover !important;
         min-height: 320px;
     }
+
+    .grommetux-pulse__icon svg {
+        padding: 10px;
+        path {
+            transform: scale(0.8) translate(3.3px, 3.3px)
+        }
+    }
 }


### PR DESCRIPTION
I found one css bug with overlapping mail icon inside pulse effect.
![Zrzut ekranu 2019-10-26 o 10 51 56](https://user-images.githubusercontent.com/30760855/67616999-10045d80-f7df-11e9-8d9e-ef411400a570.png)
